### PR TITLE
Support for Semantic 2.x, Unpegged "templating" pkg version.

### DIFF
--- a/package.js
+++ b/package.js
@@ -19,11 +19,8 @@ Package.on_use(function(api) {
    * Add files that should be used with this
    * package.
    */
-  api.use([
-    "templating@1.1.1",
-    "semantic:ui-css@1.11.6",
-    "semantic:ui-modal@1.11.6"
-  ], "client");
+  api.use("templating", "client");
+  api.use("semantic:ui-css@1.0.0 || 2.0.0", "client");
 
   api.add_files([
     "semantic-ui-modal.html",


### PR DESCRIPTION
Hey there,

Great little package you have.  Solves the main problem I had with Modal's in Meteor (binding events).  Trying to allow it to use Semantic 2.0, ran into the problem of a cross-dependency with `semantic-modal` and `semantic-css`.

`semantic-modal` is a single-component release and `semantic-css` is the entire Semantic-UI release (already inclusive of `semantic-modal`).  This didn't use to cause a problem, but was double-defining things.

More importantly, it's made it difficult to support both 1.x and 2.x because of a cross-dependency.  I removed it and left `semantic-ui` which will still support all of your users.  This at least let's your users choose which version they want to use too.  Ideally, I don't think this should have a dependency on either, in order to let the user choose how much or how little Semantic they want to install, but that's another discussion. :)

So, this pull-request:
- Removed redundant "semantic:modal" package (already in semantic-css)
- Allows both 1.x and 2.x version of Semantic
- Removed Pegged "templating" pkg version

Cheers :)
