### PR TITLE
Better post-modal cleanup, less hardcoded, and a bit of cleanup.

### DIFF
--- a/semantic-ui-modal.html
+++ b/semantic-ui-modal.html
@@ -1,5 +1,5 @@
 <template name="confirmModalWrapper">
-	<div class="ui small modal" id="confirmModal">
+	<div class="ui small modal">
 	{{>confirmModal}}
 	</div>
 </template>
@@ -28,7 +28,7 @@
 </template>
 
 <template name="generalModalWrapper">
-  <div class="ui modal {{modalClass}}" id="generalModal">
+  <div class="ui modal {{modalClass}}">
     {{> Template.dynamic template=templateName data=dataContext}}
   </div>
 </template>

--- a/semantic-ui-modal.html
+++ b/semantic-ui-modal.html
@@ -1,30 +1,30 @@
 <template name="confirmModalWrapper">
-	<div class="ui small modal">
-	{{>confirmModal}}
-	</div>
+  <div class="ui small modal">
+    {{>confirmModal}}
+  </div>
 </template>
 
 <template name="confirmModal">
-   {{#if header}}
-   	<div class="header">
-    {{header}}
-  	</div>
-  	{{/if}}
-  	<div class="content">
-		{{{message}}}
-  	</div>
-		{{#unless noButtons}}
-		<div class="actions">
-  		<div class="ui negative button" id="confirmCancel">
-  			<i class="remove icon"></i>
-  			Cancel
-  		</div>
-  		<div class="ui positive button" id="confirmOkay">
-  			<i class="checkmark icon"></i>
-  			Okay
-  		</div>
-  		</div>
-  		{{/unless}}
+  {{#if header}}
+    <div class="header">
+      {{header}}
+    </div>
+  {{/if}}
+  <div class="content">
+    {{{message}}}
+  </div>
+  {{#unless noButtons}}
+    <div class="actions">
+      <div class="ui negative button" id="confirmCancel">
+        <i class="remove icon"></i>
+        Cancel
+      </div>
+      <div class="ui positive button" id="confirmOkay">
+        <i class="checkmark icon"></i>
+        Okay
+      </div>
+    </div>
+  {{/unless}}
 </template>
 
 <template name="generalModalWrapper">

--- a/semantic-ui-modal.js
+++ b/semantic-ui-modal.js
@@ -21,7 +21,7 @@ confirmModal = function(options, postRender) {
           verbose: false,
           closable: options ? options.noButtons : null
         }).modal('show');
-        postRender && postRender.call(instance, options);
+        if ( postRender ) postRender.call(instance, options);
     },
     {
       message: options && options.message,
@@ -30,8 +30,8 @@ confirmModal = function(options, postRender) {
       delay: options && options.delay,
       noButtons: options && options.noButtons
     }
-  )
-}
+  );
+};
 
 generalModal = function(template, data, options) {
   templateAttach(
@@ -46,7 +46,7 @@ generalModal = function(template, data, options) {
       }))
       .modal('show')
       .modal('refresh');
-      options && options.postRender && options.postRender.call(this, options);
+      if ( options && options.postRender ) options.postRender.call(this, options);
     },
     {
       dataContext: data,
@@ -65,9 +65,9 @@ Template.confirmModal.events({
       instance = Template.instance(),
       delayTime = $(template.firstNode.offsetParent).modal('setting', 'duration');
 
-    this.callback && this.callback.apply(this, arguments);
-    this.delay && Meteor.setTimeout(function() {
-      _this.delay.apply(_this, arguments)
+    if ( this.callback ) this.callback.apply(this, arguments);
+    if ( this.delay ) Meteor.setTimeout(function() {
+      _this.delay.apply(_this, arguments);
     }, delayTime);
     template.$(template.firstNode.offsetParent).modal('hide');
   }

--- a/semantic-ui-modal.js
+++ b/semantic-ui-modal.js
@@ -1,83 +1,83 @@
 templateAttach = function(template, callback, data) {
-	var instance;
-	if (typeof template === "string") template = Template[template];
-	if (!template) return false;
-	if (data)
-		instance = Blaze.renderWithData(template, data, document.body);
-	else
-		instance = Blaze.render(template, document.body);
-	return callback && callback.call(this, instance);
+  var instance;
+  if (typeof template === "string") template = Template[template];
+  if (!template) return false;
+  if (data)
+    instance = Blaze.renderWithData(template, data, document.body);
+  else
+    instance = Blaze.render(template, document.body);
+  return callback && callback.call(this, instance);
 };
 
 confirmModal = function(options, postRender) {
-	templateAttach(
-		Template.confirmModalWrapper,
-		function(instance) {
-	  		$('#confirmModal').modal('setting', {
-		    	onHide: function() {
-		      		Meteor.setTimeout(function() {
-			    		$('.ui.dimmer.page').remove();
-			    		$('#confirmModal').remove();
-		  	  		}, $(this).modal('setting', 'duration'));
-		    	},
-	    		debug: false,
-	    		verbose: false,
-	    		closable: options ? options.noButtons : null
-	  		}).modal('show');
-		  	postRender && postRender.call(instance, options);
-		},
-		{
-			message: options && options.message,
-			header: options && options.header,
-			callback: options && options.callback,
-			delay: options && options.delay,
-			noButtons: options && options.noButtons
-		}
-	);
+  templateAttach(
+    Template.confirmModalWrapper,
+    function(instance) {
+        $('#confirmModal').modal('setting', {
+          onHide: function() {
+              Meteor.setTimeout(function() {
+              $('.ui.dimmer.page').remove();
+              $('#confirmModal').remove();
+              }, $(this).modal('setting', 'duration'));
+          },
+          debug: false,
+          verbose: false,
+          closable: options ? options.noButtons : null
+        }).modal('show');
+        postRender && postRender.call(instance, options);
+    },
+    {
+      message: options && options.message,
+      header: options && options.header,
+      callback: options && options.callback,
+      delay: options && options.delay,
+      noButtons: options && options.noButtons
+    }
+  );
 };
 
 generalModal = function(template, data, options) {
-	templateAttach(
-		Template.generalModalWrapper,
-		function() {
-		  $('#generalModal').modal('setting', _.extend( (options ? options.modalSettings : {}) || {}, {
-			    onHide: function() {
-			      Meteor.setTimeout(function() {
-				    $('.ui.dimmer.page').remove();
-				    $('#generalModal').remove();
-				  }, $(this).modal('setting', 'duration'));
-			    },
-			    debug: false,
-			    verbose: false
-		  }))
-		  .modal('show')
-		  .modal('refresh');
-			options && options.postRender && options.postRender.call(this, options);
-		},
-		{
-			dataContext: data,
-			templateName: template,
-			modalClass: options && options.modalClass,
-			modal: $('#generalModal')[0]
-		}
-	)
+  templateAttach(
+    Template.generalModalWrapper,
+    function() {
+      $('#generalModal').modal('setting', _.extend( (options ? options.modalSettings : {}) || {}, {
+          onHide: function() {
+            Meteor.setTimeout(function() {
+            $('.ui.dimmer.page').remove();
+            $('#generalModal').remove();
+          }, $(this).modal('setting', 'duration'));
+          },
+          debug: false,
+          verbose: false
+      }))
+      .modal('show')
+      .modal('refresh');
+      options && options.postRender && options.postRender.call(this, options);
+    },
+    {
+      dataContext: data,
+      templateName: template,
+      modalClass: options && options.modalClass,
+      modal: $('#generalModal')[0]
+    }
+  )
 }
 
 Template.confirmModal.events({
-	'click #confirmCancel': function(event, template) {
-		$(template.firstNode.offsetParent).modal('hide');
-	},
-	'click #confirmOkay': function(event, template) {
-		var _this = this,
-			instance = Template.instance(),
-			delayTime = $(template.firstNode.offsetParent).modal('setting', 'duration');
+  'click #confirmCancel': function(event, template) {
+    $(template.firstNode.offsetParent).modal('hide');
+  },
+  'click #confirmOkay': function(event, template) {
+    var _this = this,
+      instance = Template.instance(),
+      delayTime = $(template.firstNode.offsetParent).modal('setting', 'duration');
 
-		this.callback && this.callback.apply(this, arguments);
-		this.delay && Meteor.setTimeout(function() {
-			_this.delay.apply(_this, arguments)
-		}, delayTime);
-		template.$(template.firstNode.offsetParent).modal('hide');
-	}
+    this.callback && this.callback.apply(this, arguments);
+    this.delay && Meteor.setTimeout(function() {
+      _this.delay.apply(_this, arguments)
+    }, delayTime);
+    template.$(template.firstNode.offsetParent).modal('hide');
+  }
 });
 
 SemanticModal = {

--- a/semantic-ui-modal.js
+++ b/semantic-ui-modal.js
@@ -53,8 +53,8 @@ generalModal = function(template, data, options) {
       templateName: template,
       modalClass: options && options.modalClass
     }
-  )
-}
+  );
+};
 
 Template.confirmModal.events({
   'click #confirmCancel': function(event, template) {

--- a/semantic-ui-modal.js
+++ b/semantic-ui-modal.js
@@ -13,7 +13,7 @@ confirmModal = function(options, postRender) {
   templateAttach(
     Template.confirmModalWrapper,
     function(instance) {
-        $('#confirmModal').modal('setting', {
+        $(instance.firstNode()).modal('setting', {
           onHidden: function () {
             Blaze.remove(instance);
           },
@@ -37,7 +37,7 @@ generalModal = function(template, data, options) {
   templateAttach(
     Template.generalModalWrapper,
     function(instance) {
-      $('#generalModal').modal('setting', _.extend( (options ? options.modalSettings : {}) || {}, {
+      $(instance.firstNode()).modal('setting', _.extend( (options ? options.modalSettings : {}) || {}, {
           onHidden: function() {
             Blaze.remove(instance);
           },
@@ -51,8 +51,7 @@ generalModal = function(template, data, options) {
     {
       dataContext: data,
       templateName: template,
-      modalClass: options && options.modalClass,
-      modal: $('#generalModal')[0]
+      modalClass: options && options.modalClass
     }
   )
 }

--- a/semantic-ui-modal.js
+++ b/semantic-ui-modal.js
@@ -14,11 +14,8 @@ confirmModal = function(options, postRender) {
     Template.confirmModalWrapper,
     function(instance) {
         $('#confirmModal').modal('setting', {
-          onHide: function() {
-              Meteor.setTimeout(function() {
-              $('.ui.dimmer.page').remove();
-              $('#confirmModal').remove();
-              }, $(this).modal('setting', 'duration'));
+          onHidden: function () {
+            Blaze.remove(instance);
           },
           debug: false,
           verbose: false,
@@ -33,19 +30,16 @@ confirmModal = function(options, postRender) {
       delay: options && options.delay,
       noButtons: options && options.noButtons
     }
-  );
-};
+  )
+}
 
 generalModal = function(template, data, options) {
   templateAttach(
     Template.generalModalWrapper,
-    function() {
+    function(instance) {
       $('#generalModal').modal('setting', _.extend( (options ? options.modalSettings : {}) || {}, {
-          onHide: function() {
-            Meteor.setTimeout(function() {
-            $('.ui.dimmer.page').remove();
-            $('#generalModal').remove();
-          }, $(this).modal('setting', 'duration'));
+          onHidden: function() {
+            Blaze.remove(instance);
           },
           debug: false,
           verbose: false

--- a/semantic-ui-modal.js
+++ b/semantic-ui-modal.js
@@ -37,7 +37,7 @@ generalModal = function(template, data, options) {
   templateAttach(
     Template.generalModalWrapper,
     function(instance) {
-      $(instance.firstNode()).modal('setting', _.extend( (options ? options.modalSettings : {}) || {}, {
+      $(instance.firstNode()).modal('setting', _.extend( {}, (options ? options.modalSettings : {}), {
           onHidden: function() {
             Blaze.remove(instance);
           },


### PR DESCRIPTION
Probably best to review the commits to see what I did.

The main thing I went in to fix was the way it cleaned up after it was done.  The wrapper wasn't getting properly destroyed with Blaze.remove() [see here (in red) about Blaze.remove requirements to using Blaze.render*](http://docs.meteor.com/#/full/blaze_render).  Additionally, it was a bit overzealous about the other way it cleaned up because it destroyed Semantic-UI's global modal DIV (potentially used by other modals).

Then just general cleanup (tabs2spaces, JSHint).

Support is theoretically there now for multiple modals (on top of each other, or triggered by the buttons), but I didn't go that far, but namespace-wise, it's ready.
